### PR TITLE
Pin the nightly Rust toolchain with a config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,7 @@ Cargo.lock
 
 # Systrace specific things
 
-bin/systrace
+bin/reverie
 tests/clock-nanosleep
 tests/forkExec
 tests/forkMany
@@ -77,6 +77,7 @@ tests/getpid-pie
 tests/nanosleep
 tests/open-many
 tests/openat1
+tests/openat2
 tests/segfault
 tests/signal1
 tests/signal2
@@ -95,13 +96,16 @@ tests/threads7
 tests/write-many
 tests/x64-save-return-address
 examples/counter/src/ffi.rs
+examples/counter/src/consts.rs
 examples/echo/src/ffi.rs
+examples/echo/src/consts.rs
+examples/det/src/ffi.rs
+examples/det/src/consts.rs
 examples/none/src/ffi.rs
+examples/none/src/consts.rs
 src/nr.rs
 syscalls/src/nr.rs
 tools_helper/src/consts.rs
 tools_helper/src/state.rs
 tools_helper/src/local_state.rs
-examples/det/src/ffi.rs
-examples/echo/src/consts.rs
 preloader/src/consts.rs

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
With a [rust-toolchain](https://github.com/rust-lang/rustup.rs#the-toolchain-file) file, we no longer have to `rustup override set nightly`/`cargo +nightly build` to get Cargo to use the correct toolchain.