### PR TITLE
Update procfs dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -356,13 +356,13 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.5.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "libflate 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -480,7 +480,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "paw 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "procfs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "procfs 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "reverie-api 0.1.0",
  "reverie-common 0.1.0",
  "reverie-seccomp 0.1.0",
@@ -529,7 +529,7 @@ dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "procfs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "procfs 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "reverie-common 0.1.0",
  "reverie-seccomp 0.1.0",
  "syscalls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -804,7 +804,7 @@ dependencies = [
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "e3fa261d919c1ae9d1e4533c4a2f99e10938603c4208d56c05bec7a872b661b0"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-"checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+"checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -823,7 +823,7 @@ dependencies = [
 "checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afdc77cc74ec70ed262262942ebb7dac3d479e9e5cfa2da1841c0806f6cdabcc"
-"checksum procfs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7fedbab4f73bb05650bf3a74a925f6f0351f6978303e0b9570d3b677cbbde4c7"
+"checksum procfs 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c81c52c5396135378949a5a71a04339c1e6129f67cd58a62fd4c00d2fa0f177e"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"

--- a/reverie-preloader/Cargo.toml
+++ b/reverie-preloader/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 syscalls = "0.1"
 reverie-common = { path = "../reverie-common" }
 reverie-seccomp = { path = "../reverie-seccomp" }
-procfs = "0.5"
+procfs = "0.7"
 nix = "0.15"
 libc = "0.2"
 

--- a/reverie-preloader/src/relink.rs
+++ b/reverie-preloader/src/relink.rs
@@ -4,7 +4,7 @@
 
 use nix::unistd;
 use procfs;
-use procfs::MemoryMap;
+use procfs::process::MemoryMap;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::ptr::NonNull;
@@ -49,7 +49,7 @@ fn into_ranges(
     maps.iter()
         .skip_while(|e| e.address.0 != base)
         .take_while(|e| match &e.pathname {
-            procfs::MMapPath::Path(p) => p == name,
+            procfs::process::MMapPath::Path(p) => p == name,
             _ => false,
         })
         .cloned()
@@ -71,7 +71,7 @@ pub fn dl_open_ns(dso: String) -> Vec<LinkMap> {
     let mut res: Vec<LinkMap> = Vec::new();
 
     let head = std::ptr::NonNull::new(handle as *mut ll_link_map);
-    let maps = procfs::Process::new(pid.as_raw())
+    let maps = procfs::process::Process::new(pid.as_raw())
         .and_then(|p| p.maps())
         .unwrap();
 

--- a/reverie/Cargo.toml
+++ b/reverie/Cargo.toml
@@ -25,7 +25,7 @@ reverie-common = { path = "../reverie-common" }
 reverie-seccomp = { path = "../reverie-seccomp" }
 nix = "0.15"
 goblin = "0.0"
-procfs = "0.5"
+procfs = "0.7"
 lazy_static = "1.4"
 colored = "1.7"
 chrono = "0.4"

--- a/reverie/src/patcher.rs
+++ b/reverie/src/patcher.rs
@@ -310,7 +310,7 @@ pub fn patch_syscall_at(
 /// search for spare page(s) which can be allocated (mmap) within the
 /// range of @addr_hint +/- 2GB.
 pub fn search_stub_page(pid: Pid, addr_hint: u64, pages: usize) -> Result<u64> {
-    let mappings = procfs::Process::new(pid.as_raw())
+    let mappings = procfs::process::Process::new(pid.as_raw())
         .and_then(|p| p.maps())
         .unwrap_or_else(|_| Vec::new());
     let page_size: u64 = 0x1000;
@@ -364,13 +364,13 @@ pub fn search_stub_page(pid: Pid, addr_hint: u64, pages: usize) -> Result<u64> {
 #[test]
 fn can_find_stub_page() {
     let pid = unistd::getpid();
-    let ranges: Vec<_> = procfs::Process::new(pid.as_raw())
+    let ranges: Vec<_> = procfs::process::Process::new(pid.as_raw())
         .and_then(|p| p.maps())
         .unwrap_or_else(|_| Vec::new())
         .iter()
         .map(|e| e.address)
         .collect();
-    let addr_hints: Vec<u64> = procfs::Process::new(pid.as_raw())
+    let addr_hints: Vec<u64> = procfs::process::Process::new(pid.as_raw())
         .and_then(|p| p.maps())
         .unwrap_or_else(|_| Vec::new())
         .iter()

--- a/reverie/src/sched_wait.rs
+++ b/reverie/src/sched_wait.rs
@@ -304,8 +304,9 @@ pub fn sched_wait_event_loop<G>(sched: &mut SchedWait<G>) -> i32 {
                 // task not to be re-queued, assuming exited/killed.
                 log::debug!("[sched] {} failed to run, assuming killed", tid);
                 if log::log_enabled!(log::Level::Trace) {
-                    if let Ok(status) = procfs::Process::new(tid.as_raw())
-                        .and_then(|p| p.status())
+                    if let Ok(status) =
+                        procfs::process::Process::new(tid.as_raw())
+                            .and_then(|p| p.status())
                     {
                         log::trace!("[sched] task {} refused to be traced while alive, {:?}", tid, status);
                         let regs = ptrace::getregs(tid);

--- a/reverie/src/vdso.rs
+++ b/reverie/src/vdso.rs
@@ -99,11 +99,11 @@ lazy_static! {
 // so that we don't have to decode vdso for each process
 fn vdso_get_symbols_info() -> HashMap<String, (u64, usize)> {
     let mut res: HashMap<String, (u64, usize)> = HashMap::new();
-    procfs::Process::new(unistd::getpid().as_raw())
+    procfs::process::Process::new(unistd::getpid().as_raw())
         .and_then(|p| p.maps())
         .unwrap_or_else(|_| Vec::new())
         .iter()
-        .find(|e| e.pathname == procfs::MMapPath::Vdso)
+        .find(|e| e.pathname == procfs::process::MMapPath::Vdso)
         .and_then(|vdso| {
             let slice = unsafe {
                 std::slice::from_raw_parts(
@@ -132,11 +132,11 @@ fn vdso_get_symbols_info() -> HashMap<String, (u64, usize)> {
 
 #[test]
 fn can_find_vdso() {
-    assert!(procfs::Process::new(unistd::getpid().as_raw())
+    assert!(procfs::process::Process::new(unistd::getpid().as_raw())
         .and_then(|p| p.maps())
         .unwrap_or_else(|_| Vec::new())
         .iter()
-        .filter(|e| e.pathname == procfs::MMapPath::Vdso)
+        .filter(|e| e.pathname == procfs::process::MMapPath::Vdso)
         .next()
         .is_some());
 }
@@ -158,11 +158,11 @@ fn vdso_patch_info_is_valid() {
 ///
 /// `task` must be in stopped state.
 pub fn vdso_patch(task: &mut TracedTask) -> Result<()> {
-    if let Some(vdso) = procfs::Process::new(task.getpid().as_raw())
+    if let Some(vdso) = procfs::process::Process::new(task.getpid().as_raw())
         .and_then(|p| p.maps())
         .unwrap_or_else(|_| Vec::new())
         .iter()
-        .find(|e| e.pathname == procfs::MMapPath::Vdso)
+        .find(|e| e.pathname == procfs::process::MMapPath::Vdso)
     {
         task.untraced_syscall(
             SYS_mprotect,


### PR DESCRIPTION
This commit updates procfs to version v0.7.  The previous versions of
procfs would panic if it encountered a bug or assertion failure.  This
new version no longer does this (and so is much more friendly), and
instead it will simply return an error.

The change to how errors are handled was itself not an API breaking change, but this new version also changes the module layout a bit.  All of the code changes in this PR are due to this API change.

As the author of the `procfs` crate, I thank you for using it, and hope this pull request helps keep this dependency up-to-date.